### PR TITLE
build: update required npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "engines": {
     "node": ">=18",
-    "npm": ">=9.8.1",
+    "npm": ">=9",
     "yarn": "please-use-npm",
     "pnpm": "please-use-npm"
   },


### PR DESCRIPTION
Required npm version was higher than what Vercel uses to build and deploy