### PR TITLE
fix: shopify page query

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,4 @@
-export const SHOPIFY_GRAPHQL_API_ENDPOINT = '/api/2023-10/graphql.json';
+export const SHOPIFY_GRAPHQL_API_ENDPOINT = '/api/2023-01/graphql.json';
 export const HIDDEN_PRODUCT_TAG = 'nextjs-frontend-hidden';
 
 export const TAGS = {


### PR DESCRIPTION
CLOSED: if want to see realtime updates on shopify page content need to change cache prop in shopify fetch function, otherwise have to manually redeploy site with current setup to see page content changes.